### PR TITLE
Defer reply if not already deferred

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,16 @@ const paginationEmbed = async (interaction, pages, buttonList, timeout = 120000)
     );
   if (buttonList.length !== 2) throw new Error("Need two buttons.");
   
-  await interaction.deferReply();
-  
   let page = 0;
 
   const row = new MessageActionRow().addComponents(buttonList);
   
-  const curPage = await interaction.reply({
+  //has the interaction already been deferred? If not, defer the reply.
+  if (interaction.deferred == false){
+    await interaction.deferReply()
+  };
+
+  const curPage = await interaction.editReply({
     embeds: [pages[page].setFooter(`Page ${page + 1} / ${pages.length}`)],
     components: [row],fetchReply: true,
   });


### PR DESCRIPTION
This has been tested with both deferred and non-deferred replies. Since there's no minimum limit on replying after deferral, it might be best to defer all replies in order to save on lines where methods would be changed depending on whether it's been deferred or not, especially since it ends up deferred later on down the line.