### PR TITLE
Ensure the collector wasn't ended by `messageDelete`

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const paginationEmbed = async (
     await interaction.deferReply();
   }
 
-  const curPage = await interaction.editReply({
+  const curPage = await interaction.reply({
     embeds: [pages[page].setFooter(`Page ${page + 1} / ${pages.length}`)],
     components: [row],
     fetchReply: true,

--- a/index.js
+++ b/index.js
@@ -13,7 +13,12 @@ const {
  * @param {number} timeout
  * @returns
  */
-const paginationEmbed = async (interaction, pages, buttonList, timeout = 120000) => {
+const paginationEmbed = async (
+  interaction,
+  pages,
+  buttonList,
+  timeout = 120000
+) => {
   if (!pages) throw new Error("Pages are not given.");
   if (!buttonList) throw new Error("Buttons are not given.");
   if (buttonList[0].style === "LINK" || buttonList[1].style === "LINK")
@@ -21,19 +26,20 @@ const paginationEmbed = async (interaction, pages, buttonList, timeout = 120000)
       "Link buttons are not supported with discordjs-button-pagination"
     );
   if (buttonList.length !== 2) throw new Error("Need two buttons.");
-  
+
   let page = 0;
 
   const row = new MessageActionRow().addComponents(buttonList);
-  
+
   //has the interaction already been deferred? If not, defer the reply.
-  if (interaction.deferred == false){
-    await interaction.deferReply()
-  };
+  if (interaction.deferred == false) {
+    await interaction.deferReply();
+  }
 
   const curPage = await interaction.editReply({
     embeds: [pages[page].setFooter(`Page ${page + 1} / ${pages.length}`)],
-    components: [row],fetchReply: true,
+    components: [row],
+    fetchReply: true,
   });
 
   const filter = (i) =>
@@ -64,8 +70,8 @@ const paginationEmbed = async (interaction, pages, buttonList, timeout = 120000)
     collector.resetTimer();
   });
 
-  collector.on("end", () => {
-    if (!curPage.deleted) {
+  collector.on("end", (_, reason) => {
+    if (!curPage.deleted && reason !== "messageDelete") {
       const disabledRow = new MessageActionRow().addComponents(
         buttonList[0].setDisabled(true),
         buttonList[1].setDisabled(true)


### PR DESCRIPTION
Currently, if the collector "ends" due to the relevant message being deleted, the `.deleted` property (**[now deprecated](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=deleted)**) seems to fail to reflect the changes; so, it ends up trying to edit the deleted message and discord.js throws the error: `DiscordAPIError: Unknown Message`.