### PR TITLE
update deprecations

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const paginationEmbed = async (
   }
 
   const curPage = await interaction.editReply({
-    embeds: [pages[page].setFooter(`Page ${page + 1} / ${pages.length}`)],
+    embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
     components: [row],
     fetchReply: true,
   });
@@ -64,7 +64,7 @@ const paginationEmbed = async (
     }
     await i.deferUpdate();
     await i.editReply({
-      embeds: [pages[page].setFooter(`Page ${page + 1} / ${pages.length}`)],
+      embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
       components: [row],
     });
     collector.resetTimer();
@@ -77,7 +77,7 @@ const paginationEmbed = async (
         buttonList[1].setDisabled(true)
       );
       curPage.edit({
-        embeds: [pages[page].setFooter(`Page ${page + 1} / ${pages.length}`)],
+        embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
         components: [disabledRow],
       });
     }

--- a/index.js
+++ b/index.js
@@ -71,16 +71,14 @@ const paginationEmbed = async (
   });
 
   collector.on("end", (_, reason) => {
-    if (!curPage.deleted && reason !== "messageDelete") {
-      const disabledRow = new MessageActionRow().addComponents(
-        buttonList[0].setDisabled(true),
-        buttonList[1].setDisabled(true)
-      );
-      curPage.edit({
-        embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
-        components: [disabledRow],
-      });
-    }
+    const disabledRow = new MessageActionRow().addComponents(
+      buttonList[0].setDisabled(true),
+      buttonList[1].setDisabled(true)
+    );
+    curPage.edit({
+      embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
+      components: [disabledRow],
+    });
   });
 
   return curPage;

--- a/index.js
+++ b/index.js
@@ -71,14 +71,15 @@ const paginationEmbed = async (
   });
 
   collector.on("end", (_, reason) => {
-    const disabledRow = new MessageActionRow().addComponents(
-      buttonList[0].setDisabled(true),
-      buttonList[1].setDisabled(true)
-    );
-    curPage.edit({
-      embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
-      components: [disabledRow],
-    });
+    if (reason !== "messageDelete") {
+      const disabledRow = new MessageActionRow().addComponents(
+        buttonList[0].setDisabled(true),
+        buttonList[1].setDisabled(true)
+      );
+      curPage.edit({
+        embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
+        components: [disabledRow],
+      });
   });
 
   return curPage;

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ const paginationEmbed = async (
         embeds: [pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` })],
         components: [disabledRow],
       });
+    }
   });
 
   return curPage;


### PR DESCRIPTION
Passing strings to `setAuthor()` and `setFooter()` was deprecated in [discord.js v13.5.0](https://github.com/discordjs/discord.js/releases/tag/13.5.0) (https://github.com/discordjs/discord.js/pull/7153)
fixes #40 

Looks like the `Message.deleted` property was also removed in [v13.4.0](https://github.com/discordjs/discord.js/releases/tag/13.4.0) (https://github.com/discordjs/discord.js/pull/7109)
fixes #36 

I would appreciate it if this gets applied to the `msg` branch too since that's what I use :)